### PR TITLE
Export action, runInAction, inject, Provider

### DIFF
--- a/src/es6Remx/index.js
+++ b/src/es6Remx/index.js
@@ -1,4 +1,8 @@
 module.exports = {
   ...require('./remx'),
-  connect: require('./connect').connect
+  connect: require('./connect').connect,
+  action: require('mobx').action,
+  runInAction: require('mobx').runInAction,
+  inject: require('mobx-react/custom').inject,
+  Provider: require('mobx-react/custom').Provider
 };

--- a/src/es6Remx/integrationTests/InjectProvider.test.js
+++ b/src/es6Remx/integrationTests/InjectProvider.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Store } from './Store';
+import { Provider, inject } from '..';
+
+describe('SmartComponent', () => {
+  let MyComponent;
+  let store;
+  let renderSpy;
+
+  beforeEach(() => {
+    store = new Store();
+    MyComponent = inject('store')(require('./SmartComponent').default);
+    renderSpy = jest.fn();
+  });
+
+  it('renders normally', () => {
+    const tree = renderer.create(
+      <Provider store={store}>
+        <MyComponent renderSpy={renderSpy} />
+      </Provider>
+    );
+    expect(tree.toJSON().children).toEqual(['nothing']);
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/integrationTest.test.js
+++ b/src/integrationTest.test.js
@@ -3,11 +3,19 @@ describe('integration test for using remx', () => {
     global.Proxy = {};
     const remx = require('./index');
     expect(remx.__versionType).toBe('es6');
+    expect(remx.action).toBeDefined();
+    expect(remx.runInAction).toBeDefined();
+    expect(remx.Provider).toBeDefined();
+    expect(remx.inject).toBeDefined();
   });
 
   it('should use legacy remx if Proxy is not available', () => {
     global.Proxy = undefined;
     const remx = require('./index');
     expect(remx.__versionType).toBe('legacy');
+    expect(remx.action).toBeDefined();
+    expect(remx.runInAction).toBeDefined();
+    expect(remx.Provider).toBeDefined();
+    expect(remx.inject).toBeDefined();
   });
 });

--- a/src/legacyRemx/index.js
+++ b/src/legacyRemx/index.js
@@ -1,4 +1,8 @@
 module.exports = {
   ...require('./remx'),
-  connect: require('./connect').connect
+  connect: require('./connect').connect,
+  action: require('mobx').action,
+  runInAction: require('mobx').runInAction,
+  inject: require('mobx-react/custom').inject,
+  Provider: require('mobx-react/custom').Provider
 };


### PR DESCRIPTION
Exported Provider and inject helpers from mobx-react to pass stores via context instead of using direct imports.
Exported action and runInAction to be able to group several state changes into single transaction to avoid unnecessary re-renders (e.g. const fetchItemsAction = async () => { store.setters.setLoading(true); const items = await getItems(); runInAction(() => { store.setters.setItems(items); store.setters.setLoading(false); }) })