### PR TITLE
mark componentDidMount as unsafe to avoid react 16.12 warnings

### DIFF
--- a/src/mobxReactClone.js
+++ b/src/mobxReactClone.js
@@ -552,7 +552,7 @@ function isObjectShallowModified(prev, next) {
  * ReactiveMixin
  */
 var reactiveMixin = {
-  componentWillMount: function componentWillMount() {
+  UNSAFE_componentWillMount: function UNSAFE_componentWillMount() {
     var _this = this;
 
     if (isUsingStaticRendering === true) return;
@@ -768,7 +768,7 @@ function observer(arg1, arg2) {
 }
 
 function mixinLifecycleEvents(target) {
-  patch(target, "componentWillMount", true);
+  patch(target, "UNSAFE_componentWillMount", true);
   ["componentDidMount", "componentWillUnmount", "componentDidUpdate"].forEach(function (funcName) {
     patch(target, funcName);
   });


### PR DESCRIPTION
@Niryo we might want to bump up a major version for this as this is a breaking change for older React.

Since upgrading to react 16.12 we're getting tons of these warnings:
```
 WARN  Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Hoc
```
