### PR TITLE
Don't proxify dates

### DIFF
--- a/src/es6Remx/Proxify.js
+++ b/src/es6Remx/Proxify.js
@@ -1,6 +1,7 @@
 import * as mobx from 'mobx';
 
 import isObjectLike from 'lodash.isobjectlike';
+import immutableDate from '../utils/immutableDate';
 
 const alreadyProxiedObjects = new WeakMap();
 
@@ -37,10 +38,14 @@ function proxify(obj) {
 const createObservableMap = (obj) => {
   const tracker = mobx.observable.map({}, { deep: false });
   Object.keys(obj).forEach((key) => {
-    if (isObjectLike(obj[key]) && !alreadyProxiedObjects.has(obj[key])) {
-      obj[key] = proxify(obj[key]);
+    const value = obj[key];
+    if (isObjectLike(value) && !alreadyProxiedObjects.has(value) && value instanceof Date === false) {
+      obj[key] = proxify(value);
     }
-    tracker.set(key, obj[key]);
+    if (value instanceof Date) {
+      obj[key] = immutableDate(value);
+    }
+    tracker.set(key, value);
   });
   return tracker;
 };

--- a/src/integrationTests/EdgeCases.test.js
+++ b/src/integrationTests/EdgeCases.test.js
@@ -154,6 +154,29 @@
 
       expect(() => setters.add(obj)).not.toThrow();
     });
+
+    it('supports Date', () => {
+      const date = new Date(10000);
+      const state = remx.state({ date });
+      const getters = remx.getters({ getDate() {
+        return state.date;
+      } });
+
+      expect(getters.getDate().valueOf()).toEqual(10000);
+    });
+
+    it('throws on date modification', () => {
+      const state = remx.state({ date: new Date() });
+      const getters = remx.getters({ getDate() {
+        return state.date;
+      } });
+
+      if (version !== 'legacyRemx') {
+        expect(() => getters.getDate().setHours(1)).toThrowError(
+          '[remx] attempted to call Date#setHours, modifying dates in store are disallowed, create a new Date instead'
+        );
+      }
+    });
   });
 
   describe('prod test', () => {

--- a/src/utils/immutableDate.js
+++ b/src/utils/immutableDate.js
@@ -19,7 +19,9 @@ export default function immutableDate(date) {
     'setYear'
   ].forEach((key) => {
     date[key] = () => {
-      throw new Error(`[remx] attempted to call Date#${key}, modifying dates in store are disallowed, create a new Date instead`);
+      throw new Error(
+        `[remx] attempted to call Date#${key}, modifying dates in store are disallowed, create a new Date instead`
+      );
     };
   });
   return date;

--- a/src/utils/immutableDate.js
+++ b/src/utils/immutableDate.js
@@ -1,0 +1,26 @@
+export default function immutableDate(date) {
+  date = new Date(date);
+  [
+    'setDate',
+    'setFullYear',
+    'setHours',
+    'setMilliseconds',
+    'setMinutes',
+    'setMonth',
+    'setSeconds',
+    'setTime',
+    'setUTCDate',
+    'setUTCFullYear',
+    'setUTCHours',
+    'setUTCMilliseconds',
+    'setUTCMinutes',
+    'setUTCMonth',
+    'setUTCSeconds',
+    'setYear'
+  ].forEach((key) => {
+    date[key] = () => {
+      throw new Error(`[remx] attempted to call Date#${key}, modifying dates in store are disallowed, create a new Date instead`);
+    };
+  });
+  return date;
+}

--- a/src/utils/immutableDate.test.js
+++ b/src/utils/immutableDate.test.js
@@ -17,4 +17,9 @@ describe('immutableDate', () => {
     const date = new Date();
     expect(date).not.toBe(immutableDate(date));
   });
+
+  it('should return a Date instance', () => {
+    const date = new Date();
+    expect(immutableDate(date)).toBeInstanceOf(Date);
+  });
 });

--- a/src/utils/immutableDate.test.js
+++ b/src/utils/immutableDate.test.js
@@ -1,0 +1,20 @@
+import immutableDate from './immutableDate';
+
+describe('immutableDate', () => {
+  it('should disallow setters', () => {
+    const idate = immutableDate(new Date(1000));
+    expect(() => idate.setHours(1)).toThrowError(
+      '[remx] attempted to call Date#setHours, modifying dates in store are disallowed, create a new Date instead'
+    );
+  });
+
+  it('should allow getters', () => {
+    const idate = immutableDate(new Date(1000));
+    expect(idate.getTime()).toEqual(1000);
+  });
+
+  it('should return a new object', () => {
+    const date = new Date();
+    expect(date).not.toBe(immutableDate(date));
+  });
+});


### PR DESCRIPTION
Proxified dates are not usable bacause calling any it's method
throws `TypeError: this is not a Date object`.
With this PR state should contain real instances of Date.
Those dates will be immutable because their modifications
can't be tracked.