### PR TITLE
Add error on accessing state in render w/o observer

### DIFF
--- a/src/es6Remx/Proxify.js
+++ b/src/es6Remx/Proxify.js
@@ -2,6 +2,9 @@ import * as mobx from 'mobx';
 
 import isObjectLike from 'lodash.isobjectlike';
 import immutableDate from '../utils/immutableDate';
+import { isReactUpdating } from '../utils/isReactUpdating';
+import { isRenderingObserver } from './globalState';
+import { isDev } from '../utils/isDev';
 
 const alreadyProxiedObjects = new WeakMap();
 
@@ -15,6 +18,11 @@ function proxify(obj) {
     },
     get: (target, prop) => {
       if (typeof prop === 'string') {
+        if (isDev() && isReactUpdating() && !isRenderingObserver()) {
+          console.error(
+            `[REMX] attemted to access prop '${prop}' in react component untracked by remx`
+          );
+        }
         tracker.get(prop);
         return target[prop];
       }

--- a/src/es6Remx/connect.js
+++ b/src/es6Remx/connect.js
@@ -1,6 +1,6 @@
 import isFunction from 'lodash.isfunction';
 import React from 'react';
-import { observer } from 'mobx-react';
+import { observer } from './observer';
 import * as Logger from './logger';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 

--- a/src/es6Remx/globalState.js
+++ b/src/es6Remx/globalState.js
@@ -1,0 +1,9 @@
+const globalState = {
+  renderingObserverDepth: 0
+};
+
+export const incrementRenderingObserverDepth = () => globalState.renderingObserverDepth++;
+
+export const decrementRenderingObserverDepth = () => globalState.renderingObserverDepth--;
+
+export const isRenderingObserver = () => globalState.renderingObserverDepth > 0;

--- a/src/es6Remx/observer.js
+++ b/src/es6Remx/observer.js
@@ -1,0 +1,52 @@
+import React, { Component, forwardRef } from 'react';
+import {
+  observer as mobxReactObserver,
+  Observer as MobxReactObserver
+} from 'mobx-react';
+import { incrementRenderingObserverDepth, decrementRenderingObserverDepth } from './globalState';
+import { noop } from '../utils/noop';
+
+const ReactForwardRefSymbol =
+  typeof forwardRef === 'function' && forwardRef(noop).$$typeof;
+
+const isFunctionComponent = (component) =>
+  typeof component === 'function' &&
+  (!component.prototype || !component.prototype.render) &&
+  !component.isReactClass &&
+  !Object.prototype.isPrototypeOf.call(Component, component);
+
+export default null;
+
+export const observer = (component) => {
+  // Unwrap forward refs into `<Observer>` component
+  // we need to unwrap the render, because it is the inner render that needs to be tracked,
+  // not the ForwardRef HoC
+  if (
+    ReactForwardRefSymbol &&
+    component.$$typeof === ReactForwardRefSymbol
+  ) {
+    if (typeof component.render !== 'function') {
+      throw new TypeError('render property of ForwardRef was not a function');
+    }
+    const render = makeRenderTrackable(component.render);
+    return forwardRef(() => (
+      <MobxReactObserver>
+        {() => render.apply(undefined, arguments)}
+      </MobxReactObserver>
+    ));
+  }
+
+  if (isFunctionComponent(component)) {
+    return mobxReactObserver(makeRenderTrackable(component));
+  }
+
+  component.prototype.render = makeRenderTrackable(component.prototype.render);
+  return mobxReactObserver(component);
+};
+
+const makeRenderTrackable = (render) => function () {
+  incrementRenderingObserverDepth();
+  const result = render.apply(this, arguments);
+  decrementRenderingObserverDepth();
+  return result;
+};

--- a/src/es6Remx/observer.test.js
+++ b/src/es6Remx/observer.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { observer } from './observer';
+import { incrementRenderingObserverDepth, decrementRenderingObserverDepth } from './globalState';
+import { grabConsole } from '../utils/testUtils';
+
+jest.mock('./globalState', () => ({
+  incrementRenderingObserverDepth: jest.fn(),
+  decrementRenderingObserverDepth: jest.fn()
+}));
+
+describe('observer', () => {
+  it('wraps render for FC', () => {
+    const Comp = observer(() => null);
+    const tree = renderer.create(
+      <Comp />,
+    );
+    expect(tree.toJSON()).toEqual(null);
+    expect(incrementRenderingObserverDepth).toHaveBeenCalledTimes(1);
+    expect(decrementRenderingObserverDepth).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps render for FC', () => {
+    const Comp = observer(React.forwardRef(() => null));
+    const tree = renderer.create(
+      <Comp />,
+    );
+    expect(tree.toJSON()).toEqual(null);
+    expect(incrementRenderingObserverDepth).toHaveBeenCalledTimes(1);
+    expect(decrementRenderingObserverDepth).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps render for CC', () => {
+    const Comp = observer(class extends React.Component {
+      render() {
+        return null;
+      }
+    });
+    const tree = renderer.create(
+      <Comp />,
+    );
+    expect(tree.toJSON()).toEqual(null);
+    expect(incrementRenderingObserverDepth).toHaveBeenCalledTimes(1);
+    expect(decrementRenderingObserverDepth).toHaveBeenCalledTimes(1);
+  });
+
+  it('Throws error when trying to forward not a function', () => {
+    expect(() => grabConsole(() => observer(React.forwardRef(undefined))))
+      .toThrowError('render property of ForwardRef was not a function');
+  });
+});

--- a/src/es6Remx/remx.js
+++ b/src/es6Remx/remx.js
@@ -2,6 +2,7 @@ import * as mobx from 'mobx';
 import isFunction from 'lodash.isfunction';
 import isObjectLike from 'lodash.isobjectlike';
 import mergeWith from '../utils/mergeWith';
+import { isDev } from '../utils/isDev';
 import { proxify } from './Proxify';
 import { logGetter, logSetter } from './logger';
 
@@ -61,12 +62,6 @@ function mergeCustomizer(objValue, srcValue, key, object) {
     object[key] = undefined;
   }
   return undefined;
-}
-
-function isDev() {
-  return global.__DEV__ ||
-    process.env.NODE_ENV === 'dev' ||
-    process.env.NODE_ENV === 'development';
 }
 
 export function toJS(data) {

--- a/src/integrationTests/UseConnectComponent.js
+++ b/src/integrationTests/UseConnectComponent.js
@@ -11,7 +11,7 @@ export default (remx) => (props) => {
   const mapStateToProps = props.mapStateToProps ?
     props.mapStateToProps :
     () => ({
-      product: props.store.getters.getProduct('123'),
+      productTitle: props.store.getters.getProduct('123') && props.store.getters.getProduct('123').title,
       dynamicObject: props.store.getters.getDynamicObject(),
       name: props.store.getters.getName()
     });
@@ -26,8 +26,8 @@ export default (remx) => (props) => {
     props.renderSpy();
   }
 
-  if (connectedProps.product) {
-    return renderText(connectedProps.product.title);
+  if (connectedProps.productTitle) {
+    return renderText(connectedProps.productTitle);
   } else if (props.testDynamicObject) {
     /* istanbul ignore next */
     return renderText(

--- a/src/integrationTests/lists/List.js
+++ b/src/integrationTests/lists/List.js
@@ -5,6 +5,12 @@ import { connect } from '../../index';
 
 import store from './Store';
 
+const Item = connect()((params) => (
+  <Text>
+    {params.item.text}
+  </Text>
+));
+
 class MyList extends Component {
   render() {
     this.props.renderSpy();
@@ -12,17 +18,13 @@ class MyList extends Component {
       <FlatList
         data={this.props.items}
         renderItem={this.renderItem}
-        keyExtractor={(i) => i.id}
+        keyExtractor={(_, i) => i}
       />
     );
   }
 
   renderItem(params) {
-    return (
-      <Text>
-        {params.item.text}
-      </Text>
-    );
+    return <Item {...params} />;
   }
 }
 

--- a/src/utils/isDev.js
+++ b/src/utils/isDev.js
@@ -1,0 +1,6 @@
+export default null;
+
+export const isDev = () =>
+  global.__DEV__ ||
+  process.env.NODE_ENV === 'dev' ||
+  process.env.NODE_ENV === 'development';

--- a/src/utils/isReactUpdating.js
+++ b/src/utils/isReactUpdating.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default null;
+
+export const isReactUpdating = () =>
+  // Please don't fire me
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED &&
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner &&
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current !== null;

--- a/src/utils/mergeWith.test.js
+++ b/src/utils/mergeWith.test.js
@@ -1,8 +1,8 @@
 /* original: https://github.com/lodash/lodash/blob/912d6b04/test/test.js#L15183 */
 import mergeWith from './mergeWith';
+import { noop } from './noop';
 
 const identity = (value) => value;
-const noop = () => {};
 
 describe('mergeWith', () => {
   it('should ignore bad sources', () => {

--- a/src/utils/noop.js
+++ b/src/utils/noop.js
@@ -1,0 +1,3 @@
+export default null;
+
+export const noop = () => undefined;

--- a/src/utils/testUtils.js
+++ b/src/utils/testUtils.js
@@ -1,7 +1,6 @@
 export default null;
 
-export const grabConsole = (fn) => {
-  const methods = ['log', 'warn', 'error', 'trace'];
+export const grabConsole = (fn, methods = ['log', 'warn', 'error', 'trace']) => {
   const originals = {};
   const calls = [];
   methods.forEach((method) => {
@@ -19,3 +18,6 @@ export const grabConsole = (fn) => {
 
   return calls;
 };
+
+export const grabConsoleErrors = (fn) => grabConsole(fn, ['error']).map((args) => args.slice(1));
+// export const grabConsoleWarns = (fn) => grabConsole(fn, ['warn']).map((args) => args.slice(1));


### PR DESCRIPTION
This feature should warn developers that they're using remx wrong. It should help to deal with the most popular bug when using remx: some React component is not updated because it's not an observer.
Remx will trigger console.error in DEV mode in cases like:

```tsx
class extends React.Component {
  render() {
    // Oops, accessing getter is prohibited here, this component is not an observer
    return <Text>{store.getters.getSomething()}</Text>
  }
}
```

```tsx
remx.connect(mapStateToProps)(class extends React.Component {
  render() {
    // Note that component itself is still not an observer when mapStateToProps is provided
    return <Text>{store.getters.getSomething()}</Text>
  }
})
```